### PR TITLE
Fix date formatting for all event pages

### DIFF
--- a/website/src/components/eventroll.js
+++ b/website/src/components/eventroll.js
@@ -5,52 +5,12 @@ import Post from "../components/post"
 import { Typography } from "@material-ui/core"
 
 class EventRoll extends React.Component {
-
-  /**
-   * Our GraphQL query will fetch every event post. This method
-   * will take those posts and filter them to return only those events
-   * that will occur on today's date and beyond. 
-   * 
-   * The date for each post is also set in UTC, so passing them into a new Date object 
-   * will convert them to the local time zone, and we will use the toLocaleTimeString and 
-   * toLocalDateString methods to format the date. This is not as elegant as
-   * it might have been with a Javascript date library like moment.js, however
-   * using native Javascript functions avoids the overhead of importing an external
-   * dependency.
-   * 
-   * This method also breaks the single responsibility principle, however the filter is
-   * currently simple enough to justify its inclusion here. Should we need to filter
-   * the posts on other criteria in the future, and be unable to do so in the query itself,
-   * it would be worthwhile to refactor that into its own method.
-   * 
-   * @param { Array } posts The array of posts returned by the GraphQL query.
-   * @returns { Array } The filtered and formatted array of posts.
-   */
-  filterAndFormatPosts = (posts) => {
-    const dateToday = new Date()
-    const dateOptions = { weekday: 'long', year: 'numeric', month: 'long', day: 'numeric'}
-    const timeOptions = { hour: 'numeric', minute: '2-digit', hour12: true}
-    return posts
-      .filter(post => new Date(post.node.frontmatter.date) >= dateToday)
-      .map(post => { 
-        const time = new Date(post.node.frontmatter.date).toLocaleTimeString('en-US', timeOptions)
-        const date = new Date(post.node.frontmatter.date).toLocaleDateString('en-US', dateOptions)
-        return { 
-          ...post, 
-          node: { 
-            ...post.node,
-            frontmatter: {
-              ...post.node.frontmatter,
-              date: time + ' ' + date
-            }
-          },
-        }
-      })
-  }
-
   render() {
     const { data } = this.props
-    const posts = this.filterAndFormatPosts(data.allMarkdownRemark.edges)
+
+    // We only want events that haven't happened yet.
+    const dateToday = new Date()
+    const posts = data.allMarkdownRemark.edges.filter(post => new Date(post.node.frontmatter.date) >= dateToday)
 
     // We use Array.prototype.find() here because
     // we are only expecting one featured post.

--- a/website/src/components/post.js
+++ b/website/src/components/post.js
@@ -43,6 +43,27 @@ const useStyles = makeStyles(theme => ({
   },
 }))
 
+/**
+ * We store the date and time for each event in UTC, so this method converts that
+ * to local time. 
+ * 
+ * Passing it into a new Date object will convert it to the local time zone, 
+ * and we will use the toLocaleTimeString and toLocalDateString methods to format the date. 
+ * This is not as elegant as it might have been with a Javascript date library like moment.js, 
+ * however using native Javascript functions avoids the overhead of importing an external
+ * dependency.
+ * 
+ * @param {string} dateUtc The event date in UTC.
+ * @returns {string} The converted and formatted date to be presented in the post.
+ */
+const formatDate = (dateUtc) => {
+  const dateOptions = { weekday: 'long', year: 'numeric', month: 'long', day: 'numeric'}
+  const timeOptions = { hour: 'numeric', minute: '2-digit', hour12: true}
+  const time = new Date(dateUtc).toLocaleTimeString('en-US', timeOptions)
+  const date = new Date(dateUtc).toLocaleDateString('en-US', dateOptions)
+  return time + ' ' + date
+}
+
 export default function Post(props) {
   // We can use this to insert the styles defined above.
   const classes = useStyles()
@@ -89,7 +110,7 @@ export default function Post(props) {
         {isEvent ? (
           <div>
             <Typography variant="h6" className={classes.eventInfo}>
-              When: {info.date}
+              When: {formatDate(info.date)}
             </Typography>
             <Typography variant="h6" className={classes.eventInfo}>
               Where: {info.where}

--- a/website/src/pages/index.js
+++ b/website/src/pages/index.js
@@ -32,7 +32,7 @@ export const pageQuery = graphql`
           frontmatter {
             title
             templateKey
-            date(formatString: "h:mma dddd, MMMM Do YYYY")
+            date
             where
             link
             featured

--- a/website/src/templates/event-post.js
+++ b/website/src/templates/event-post.js
@@ -26,6 +26,27 @@ const useStyles = makeStyles(theme => ({
   },
 }))
 
+/**
+ * We store the date and time for each event in UTC, so this method converts that
+ * to local time. 
+ * 
+ * Passing it into a new Date object will convert it to the local time zone, 
+ * and we will use the toLocaleTimeString and toLocalDateString methods to format the date. 
+ * This is not as elegant as it might have been with a Javascript date library like moment.js, 
+ * however using native Javascript functions avoids the overhead of importing an external
+ * dependency.
+ * 
+ * @param {string} dateUtc The event date in UTC.
+ * @returns {string} The converted and formatted date to be presented in the post.
+ */
+const formatDate = (dateUtc) => {
+  const dateOptions = { weekday: 'long', year: 'numeric', month: 'long', day: 'numeric'}
+  const timeOptions = { hour: 'numeric', minute: '2-digit', hour12: true}
+  const time = new Date(dateUtc).toLocaleTimeString('en-US', timeOptions)
+  const date = new Date(dateUtc).toLocaleDateString('en-US', dateOptions)
+  return time + ' ' + date
+}
+
 export default function EventPost({
   data, // this prop will be injected by the GraphQL query below.
 }) {
@@ -33,6 +54,7 @@ export default function EventPost({
   const { frontmatter, html } = markdownRemark
   const classes = useStyles()
   let path = frontmatter.link
+  const eventWhen = formatDate(frontmatter.date)
 
   // Gatsby seems to hijack all <a> tags and, if they do not begin with http://
   // or https://, appends the path to the domain instead of setting the URL as
@@ -51,7 +73,7 @@ export default function EventPost({
       </Typography>
       <div className={classes.meta}>
         <Typography variant="h6" className={classes.eventInfo}>
-          When: {frontmatter.date}
+          When: {eventWhen}
         </Typography>
         <Typography variant="h6" className={classes.eventInfo}>
           Where: {frontmatter.where}
@@ -84,7 +106,7 @@ export const pageQuery = graphql`
       }
       frontmatter {
         title
-        date(formatString: "h:mma dddd, MMMM Do YYYY")
+        date
         where
         link
         type


### PR DESCRIPTION
My previous PR #68 only fixed the date formatting for the events page; however this did not take into account each individual event page nor the index page. This fix resolves that.