### PR TITLE
Retrieve software hamilton jobs over https

### DIFF
--- a/website/src/components/opportunities-list.js
+++ b/website/src/components/opportunities-list.js
@@ -39,7 +39,7 @@ class OpportunitiesList extends React.Component {
         const { data } = this.props
         const fromFiles = data === undefined ? [] : data.allMarkdownRemark.edges
 
-        Axios.get(`http://softwarehamilton.com/wp-json/wp/v2/job-listings`)
+        Axios.get(`https://softwarehamilton.com/wp-json/wp/v2/job-listings`)
             .then(result => {
                 const shJobs = result.data.map(job => this.mapSHJobToNode(job))
                 const opportunities = fromFiles


### PR DESCRIPTION
I was seeing a 

`Mixed Content: The page at 'https://thenewdevelopers.com/opportunities' was loaded over HTTPS, but requested an insecure XMLHttpRequest endpoint 'http://softwarehamilton.com/wp-json/wp/v2/job-listings'. This request has been blocked; the content must be served over HTTPS.`

error in the console when loading the opportunities page; this should hopefully fix that.