### PR TITLE
Good first issue/86 links in where fields

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,3 @@
+{
+  "lockfileVersion": 1
+}

--- a/website/src/components/events/event-list-item.js
+++ b/website/src/components/events/event-list-item.js
@@ -52,8 +52,8 @@ const useStyles = makeStyles(theme => ({
  * @returns {string} The converted and formatted date to be presented in the post.
  */
 const formatDate = (dateUtc) => {
-  const dateOptions = { weekday: 'long', year: 'numeric', month: 'long', day: 'numeric'}
-  const timeOptions = { hour: 'numeric', minute: '2-digit', hour12: true}
+  const dateOptions = { weekday: 'long', year: 'numeric', month: 'long', day: 'numeric' }
+  const timeOptions = { hour: 'numeric', minute: '2-digit', hour12: true }
   const time = new Date(dateUtc).toLocaleTimeString('en-US', timeOptions)
   const date = new Date(dateUtc).toLocaleDateString('en-US', dateOptions)
   return time + ' ' + date
@@ -85,6 +85,19 @@ export default function EventListItem(props) {
     eventType = "Community Event"
   }
 
+  // Gatsby seems to hijack all <a> tags and, if they do not begin with http://
+  // or https://, appends the path to the domain instead of setting the URL as
+  // expected.  
+  let link = info.link
+  if (!link) link = info.where
+
+  // show link if there is a url available 
+  // TODO: is (.) dot sufficient to match any url? 
+  if (link.includes(".")) {
+    if (!link.includes("http")) link = "http://" + link
+    link = <Link to={link}>{info.where}</Link>
+  }
+
   return (
     <Card className={classes.card} elevation={0}>
       <CardContent className={classes.content}>
@@ -92,18 +105,17 @@ export default function EventListItem(props) {
         <Typography
           variant="h3"
           component="h3"
-          className={classes.title}
-        >
+          className={classes.title}>
           <Link to={props.path}>{info.title}</Link>
         </Typography>
-          <div>
-            <Typography variant="h6" className={classes.eventInfo}>
-              When: {formatDate(info.date)}
-            </Typography>
-            <Typography variant="h6" className={classes.eventInfo}>
-              Where: {info.where}
-            </Typography>
-          </div>
+        <div>
+          <Typography variant="h6" className={classes.eventInfo}>
+            When: {formatDate(info.date)}
+          </Typography>
+          <Typography variant="h6" className={classes.eventInfo}>
+            Where: {link}
+          </Typography>
+        </div>
         <Typography variant="subtitle1" className={classes.excerpt}>
           {props.info.excerpt}
         </Typography>

--- a/website/src/components/events/event-list-item.js
+++ b/website/src/components/events/event-list-item.js
@@ -7,6 +7,7 @@ import {
   CardContent,
   Typography,
 } from "@material-ui/core"
+import {checkLink} from "../../pages/index"
 
 const useStyles = makeStyles(theme => ({
   button: {
@@ -85,17 +86,6 @@ export default function EventListItem(props) {
     eventType = "Community Event"
   }
 
-  // Gatsby seems to hijack all <a> tags and, if they do not begin with http://
-  // or https://, appends the path to the domain instead of setting the URL as
-  function checkLink(param) {
-    const linkElements = ["http", "twitch", "www", ".ca", ".com"]
-
-    if (!param.includes(" ") && linkElements.some(e => param.includes(e))) {
-      if (!param.includes("http")) param = "http://" + param
-      return <Typography variant="a" component={Link} to={param}>{param}</Typography>;
-    } else return param;
-  }
-  
   return (
     <Card className={classes.card} elevation={0}>
       <CardContent className={classes.content}>

--- a/website/src/components/events/event-list-item.js
+++ b/website/src/components/events/event-list-item.js
@@ -87,15 +87,15 @@ export default function EventListItem(props) {
 
   // Gatsby seems to hijack all <a> tags and, if they do not begin with http://
   // or https://, appends the path to the domain instead of setting the URL as
-  // expected.
   function checkLink(param) {
     const someDomain = ["http", "twitch", "www", ".ca", ".com"]
 
     if (!param.includes(" ") && someDomain.some(val => param.includes(val))) {
       if (!param.includes("http")) param = "http://" + param
-      return param.includes("http") ? <Typography variant="a" component={Link} to={param}>{param}</Typography> : param;
+      return <Typography variant="a" component={Link} to={param}>{param}</Typography>;
     } else return param;
   }
+  
   return (
     <Card className={classes.card} elevation={0}>
       <CardContent className={classes.content}>

--- a/website/src/components/events/event-list-item.js
+++ b/website/src/components/events/event-list-item.js
@@ -87,17 +87,15 @@ export default function EventListItem(props) {
 
   // Gatsby seems to hijack all <a> tags and, if they do not begin with http://
   // or https://, appends the path to the domain instead of setting the URL as
-  // expected.  
-  let link = info.link
-  if (!link) link = info.where
+  // expected.
+  function checkLink(param) {
+    const someDomain = ["http", "twitch", "www", ".ca", ".com"]
 
-  // show link if there is a url available 
-  // TODO: is (.) dot sufficient to match any url? 
-  if (link.includes(".")) {
-    if (!link.includes("http")) link = "http://" + link
-    link = <Link to={link}>{info.where}</Link>
+    if (!param.includes(" ") && someDomain.some(val => param.includes(val))) {
+      if (!param.includes("http")) param = "http://" + param
+      return param.includes("http") ? <Typography variant="a" component={Link} to={param}>{param}</Typography> : param;
+    } else return param;
   }
-
   return (
     <Card className={classes.card} elevation={0}>
       <CardContent className={classes.content}>
@@ -113,7 +111,7 @@ export default function EventListItem(props) {
             When: {formatDate(info.date)}
           </Typography>
           <Typography variant="h6" className={classes.eventInfo}>
-            Where: {link}
+            Where: {checkLink(info.where)}
           </Typography>
         </div>
         <Typography variant="subtitle1" className={classes.excerpt}>

--- a/website/src/pages/index.js
+++ b/website/src/pages/index.js
@@ -9,14 +9,14 @@ export default function IndexPage({
   data, // this prop will be injected by the GraphQL query below.
 }) {
   const dateToday = new Date()
-  const featuredPost = data.allMarkdownRemark.edges && new Date(data.allMarkdownRemark.edges[0].node.frontmatter.date) >= dateToday 
-    ? data.allMarkdownRemark.edges[0] 
+  const featuredPost = data.allMarkdownRemark.edges && new Date(data.allMarkdownRemark.edges[0].node.frontmatter.date) >= dateToday
+    ? data.allMarkdownRemark.edges[0]
     : null
 
   return (
     <Layout>
       <SEO title="Home" />
-      { featuredPost && <EventListItem path={featuredPost.node.fields.slug} info={featuredPost.node} /> }
+      { featuredPost && <EventListItem path={featuredPost.node.fields.slug} info={featuredPost.node} />}
       <BlogList />
     </Layout>
   )
@@ -50,3 +50,19 @@ export const pageQuery = graphql`
     }
   }
 `
+
+// Gatsby seems to hijack all <a> tags and, if they do not begin with http://
+// or https://, appends the path to the domain instead of setting the URL as
+// expected.
+export const checkLink = function (param) {
+  const linkElements = ["http", "twitch", "www", ".ca", ".com"]
+
+  if (!param.includes(" ") && linkElements.some(e => param.includes(e))) {
+    if (!param.includes("http")) {
+      param = "http://" + param
+    }
+    return <a href={param} target="_blank" rel="noreferrer">{param}</a>;
+  } else {
+    return param;
+  }
+};

--- a/website/src/templates/event-post.js
+++ b/website/src/templates/event-post.js
@@ -65,7 +65,7 @@ export default function EventPost({
 
     if (!param.includes(" ") && someDomain.some(val => param.includes(val))) {
       if (!param.includes("http")) param = "http://" + param
-      return param.includes("http") ? <Typography variant="a" component={Link} to={param}>{param}</Typography> : param;
+      return <Typography variant="a" component={Link} to={param}>{param}</Typography>;
     } else return param;
   }
 

--- a/website/src/templates/event-post.js
+++ b/website/src/templates/event-post.js
@@ -3,6 +3,7 @@ import { graphql, Link } from "gatsby"
 import Layout from "../components/layout"
 import { makeStyles } from "@material-ui/core/styles"
 import { Button, Typography } from "@material-ui/core"
+import {checkLink} from "../pages/index"
 
 const useStyles = makeStyles(theme => ({
   body: {
@@ -55,19 +56,7 @@ export default function EventPost({
   const classes = useStyles()
   let path = frontmatter.link
 
-  // Gatsby seems to hijack all <a> tags and, if they do not begin with http://
-  // or https://, appends the path to the domain instead of setting the URL as
-  // expected.
   if (!path) path = frontmatter.where
-
-  function checkLink(param) {
-    const linkElements = ["http", "twitch", "www", ".ca", ".com"]
-
-    if (!param.includes(" ") && linkElements.some(e => param.includes(e))) {
-      if (!param.includes("http")) param = "http://" + param
-      return <Typography variant="a" component={Link} to={param}>{param}</Typography>;
-    } else return param;
-  }
 
   return (
     <Layout>

--- a/website/src/templates/event-post.js
+++ b/website/src/templates/event-post.js
@@ -40,8 +40,8 @@ const useStyles = makeStyles(theme => ({
  * @returns {string} The converted and formatted date to be presented in the post.
  */
 const formatDate = (dateUtc) => {
-  const dateOptions = { weekday: 'long', year: 'numeric', month: 'long', day: 'numeric'}
-  const timeOptions = { hour: 'numeric', minute: '2-digit', hour12: true}
+  const dateOptions = { weekday: 'long', year: 'numeric', month: 'long', day: 'numeric' }
+  const timeOptions = { hour: 'numeric', minute: '2-digit', hour12: true }
   const time = new Date(dateUtc).toLocaleTimeString('en-US', timeOptions)
   const date = new Date(dateUtc).toLocaleDateString('en-US', dateOptions)
   return time + ' ' + date
@@ -58,7 +58,16 @@ export default function EventPost({
   // Gatsby seems to hijack all <a> tags and, if they do not begin with http://
   // or https://, appends the path to the domain instead of setting the URL as
   // expected.
-  if (path && !path.includes("http")) path = "http://" + path
+  if (!path) path = frontmatter.where
+
+  // show link if there is a url available 
+  // TODO: is (.) dot sufficient to match any url? 
+  if (path.includes(".")) {
+    if (!path.includes("http")) path = "http://" + path
+    path = <Link to={path}>{frontmatter.where}</Link>
+  }
+
+
 
   return (
     <Layout>
@@ -75,7 +84,7 @@ export default function EventPost({
           When: {formatDate(frontmatter.date)}
         </Typography>
         <Typography variant="h6" className={classes.eventInfo}>
-          Where: {frontmatter.where}
+          Where: {path}
         </Typography>
       </div>
       <Typography variant="body1" className={classes.body}>
@@ -86,8 +95,7 @@ export default function EventPost({
           variant="contained"
           href={path}
           color="secondary"
-          className={classes.button}
-        >
+          className={classes.button}>
           Register
         </Button>
       ) : null}

--- a/website/src/templates/event-post.js
+++ b/website/src/templates/event-post.js
@@ -60,14 +60,14 @@ export default function EventPost({
   // expected.
   if (!path) path = frontmatter.where
 
-  // show link if there is a url available 
-  // TODO: is (.) dot sufficient to match any url? 
-  if (path.includes(".")) {
-    if (!path.includes("http")) path = "http://" + path
-    path = <Link to={path}>{frontmatter.where}</Link>
+  function checkLink(param) {
+    const someDomain = ["http", "twitch", "www", ".ca", ".com"]
+
+    if (!param.includes(" ") && someDomain.some(val => param.includes(val))) {
+      if (!param.includes("http")) param = "http://" + param
+      return param.includes("http") ? <Typography variant="a" component={Link} to={param}>{param}</Typography> : param;
+    } else return param;
   }
-
-
 
   return (
     <Layout>
@@ -84,7 +84,7 @@ export default function EventPost({
           When: {formatDate(frontmatter.date)}
         </Typography>
         <Typography variant="h6" className={classes.eventInfo}>
-          Where: {path}
+          Where: {checkLink(path)}
         </Typography>
       </div>
       <Typography variant="body1" className={classes.body}>


### PR DESCRIPTION
Hi @rodneybarnes, sorry I just messed up with last PR, so just created a new one (deleting old).
I have applied your suggestions,

I used a function that takes value of `info.where` and check if it contains some link related keywords 
(like:  `const linkElements = ["http", "twitch", "www", ".ca", ".com"]`).

if any of these contained in the text (`info.where`), it treated as a link or return the text as it is.

I have also added `twitch` because most of links points towards it.

still, it's not a great a solution, but we can use Regular Expressions that will help to convert mixed links,
i.e. `twitch.tv/thenewdevelopers AND The New Developers Discord Server`. to transform a part of the text into clickable.

I know you also have other important works to do, but Thank You so much for the response, 
and please let me if I can further improve this.