### PR TITLE
Fix filtering for featured event so that it shows on the main page

### DIFF
--- a/website/src/pages/index.js
+++ b/website/src/pages/index.js
@@ -8,9 +8,8 @@ import SEO from "../components/seo"
 export default function IndexPage({
   data, // this prop will be injected by the GraphQL query below.
 }) {
-  const dateToday = new Date()
-  const featuredPost = data.allMarkdownRemark.edges && new Date(data.allMarkdownRemark.edges[0].node.frontmatter.date) >= dateToday
-    ? data.allMarkdownRemark.edges[0]
+  const featuredPost = data.allMarkdownRemark.edges
+    ? data.allMarkdownRemark.edges.sort((firstEdge, secondEdge) => new Date(secondEdge.node.frontmatter.date) - new Date(firstEdge.node.frontmatter.date))[0]
     : null
 
   return (

--- a/website/src/pages/index.js
+++ b/website/src/pages/index.js
@@ -8,9 +8,12 @@ import SEO from "../components/seo"
 export default function IndexPage({
   data, // this prop will be injected by the GraphQL query below.
 }) {
-  const featuredPost = data.allMarkdownRemark.edges
-    ? data.allMarkdownRemark.edges.sort((firstEdge, secondEdge) => new Date(secondEdge.node.frontmatter.date) - new Date(firstEdge.node.frontmatter.date))[0]
-    : null
+  const today = new Date();
+  const mostRecentFeaturedEvent = data.allMarkdownRemark.edges &&
+    data.allMarkdownRemark.edges.sort((firstEdge, secondEdge) => new Date(secondEdge.node.frontmatter.date) - new Date(firstEdge.node.frontmatter.date))[0];
+  const featuredPost = new Date(mostRecentFeaturedEvent.node.frontmatter.date) >= today 
+    ? mostRecentFeaturedEvent 
+    : null;
 
   return (
     <Layout>


### PR DESCRIPTION
Before, we were taking the first in the list of all event posts marked "featured" and only displaying it if its date was in the future. This required some upkeep in our content, to go through any past featured events and make sure they no longer had the "feature" flag toggled on.

Instead, this change sorts all featured events by date descending before checking if the most recent event is in the future, and then only displays it if it is in the future.