### PR TITLE
Fix event post logic

### DIFF
--- a/website/src/common/check-link.js
+++ b/website/src/common/check-link.js
@@ -1,4 +1,4 @@
-import React from "react"
+import React from "react";
 // Gatsby seems to hijack all <a> tags and, if they do not begin with http://
 // or https://, appends the path to the domain instead of setting the URL as
 // expected.

--- a/website/src/common/check-link.js
+++ b/website/src/common/check-link.js
@@ -1,5 +1,4 @@
-import React from "react";
-
+import React from "react"
 // Gatsby seems to hijack all <a> tags and, if they do not begin with http://
 // or https://, appends the path to the domain instead of setting the URL as
 // expected.

--- a/website/src/pages/index.js
+++ b/website/src/pages/index.js
@@ -52,18 +52,3 @@ export const pageQuery = graphql`
     }
   }
 `
-
-// Gatsby seems to hijack all <a> tags and, if they do not begin with http://
-// or https://, appends the path to the domain instead of setting the URL as
-// expected.
-export const checkLink = function (param) {
-  const linkElements = ["http", "twitch", "www", ".ca", ".com"]
-  if (!param.includes(" ") && linkElements.some(e => param.includes(e))) {
-    if (!param.includes("http")) {
-      param = "http://" + param
-    }
-    return <a href={param} target="_blank" rel="noreferrer">{param}</a>;
-  } else {
-    return param;
-  }
-};

--- a/website/src/templates/event-post.js
+++ b/website/src/templates/event-post.js
@@ -54,9 +54,6 @@ export default function EventPost({
   const { markdownRemark } = data // data.markdownRemark holds our post data
   const { frontmatter, html } = markdownRemark
   const classes = useStyles()
-  let path = frontmatter.link
-
-  if (!path) path = frontmatter.where
 
   return (
     <Layout>
@@ -73,7 +70,7 @@ export default function EventPost({
           When: {formatDate(frontmatter.date)}
         </Typography>
         <Typography variant="h6" className={classes.eventInfo}>
-          Where: {checkLink(path)}
+          Where: {checkLink(frontmatter.where)}
         </Typography>
       </div>
       <Typography variant="body1" className={classes.body}>
@@ -82,7 +79,7 @@ export default function EventPost({
       {frontmatter.link ? (
         <Button
           variant="contained"
-          href={path}
+          href={frontmatter.link}
           color="secondary"
           className={classes.button}>
           Register


### PR DESCRIPTION
If the event post is an external event, the `frontmatter.link` will be a registration link or link to an external page, and the `frontmatter.where` will be the physical location - these must not be conflated.