### PR TITLE
Fix post content not rendering

### DIFF
--- a/website/src/templates/blog-post.js
+++ b/website/src/templates/blog-post.js
@@ -33,7 +33,7 @@ export default function BlogPost({
         <Typography variant="h6">Written by {frontmatter.author}</Typography>
         <Typography variant="overline">{frontmatter.date}</Typography>
       </div>
-      <Typography variant="body1" className={classes.body}>
+      <Typography variant="body1" component="div" className={classes.body}>
         <span dangerouslySetInnerHTML={{ __html: html }} />
       </Typography>
     </Layout>

--- a/website/src/templates/event-post.js
+++ b/website/src/templates/event-post.js
@@ -73,7 +73,7 @@ export default function EventPost({
           Where: {checkLink(frontmatter.where)}
         </Typography>
       </div>
-      <Typography variant="body1" className={classes.body}>
+      <Typography variant="body1" component="div" className={classes.body}>
         <span dangerouslySetInnerHTML={{ __html: html }} />
       </Typography>
       {frontmatter.link ? (

--- a/website/src/templates/opportunities-post.js
+++ b/website/src/templates/opportunities-post.js
@@ -36,7 +36,7 @@ export default function OpportunitiesPost({
       <Typography variant="h6">Contact: {checkLink(frontmatter.contactInfo)}
       </Typography>
       <Typography variant="h6">Website: <a href={frontmatter.organizationWebsite} target="_blank" rel="noreferrer">{frontmatter.organizationWebsite}</a></Typography>
-      <Typography variant="body1" className={classes.body}>
+      <Typography variant="body1" component="div" className={classes.body}>
         <span dangerouslySetInnerHTML={{ __html: html }} />
       </Typography>
     </Layout>


### PR DESCRIPTION
This one was tricky because I was not able to recreate it in my dev environment, however I think that helps point to this [related issue as the cause](https://github.com/gatsbyjs/gatsby/issues/11108).

If this works, it's because we were wrapping the elements that `dangerouslySetInnerHTML` in a material-ui `Typography` element, which renders in the dom as a `p` tag. The content itself was then also being rendered using `p` tags, and nested `p` tags in html are a no-no.

By explicitly telling the `Typography` elements to render as a `div`, we should hopefully not run into this error.